### PR TITLE
Initial support for CVE mitigation in Keycloak image

### DIFF
--- a/bin/scanImage.java
+++ b/bin/scanImage.java
@@ -15,7 +15,7 @@ class scanImage {
 
     static final String TRIVY_VERSION_OPT = "--trivy-version";
     static final String TRIVY_VERSION_ENV = "TRIVY_VERSION";
-    static final String TRIVY_VERSION_DEFAULT = "0.19.1";
+    static final String TRIVY_VERSION_DEFAULT = "0.19.2";
 
     static final String VERBOSE_CMD = "--verbose";
 

--- a/keycloak/cli/0001-onstart-init.cli
+++ b/keycloak/cli/0001-onstart-init.cli
@@ -125,6 +125,8 @@ end-if
 
 if (outcome == success) of /subsystem=undertow/server=default-server/ajp-listener=ajp:read-resource
   echo SETUP: Remove AJP Listener
+  # Mitigate CVE-2018-1048
+  # See: https://nvd.nist.gov/vuln/detail/CVE-2018-1048
   /subsystem=undertow/server=default-server/ajp-listener=ajp:remove()
   /socket-binding-group=standard-sockets/socket-binding=ajp:remove()
   echo

--- a/keycloak/docker/src/main/docker/keycloak/Dockerfile.alpine-slim
+++ b/keycloak/docker/src/main/docker/keycloak/Dockerfile.alpine-slim
@@ -31,7 +31,7 @@ RUN   echo "Create trimmed down JDK" && \
       --vm=server \
       --exclude-files="**/bin/rmiregistry,**/bin/jrunscript,**/bin/rmid" \
       --module-path "$JAVA_HOME/jmods" \
-      --add-modules java.base,java.instrument,java.logging,java.management,java.se,java.naming,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,java.xml.crypto,jdk.security.auth,jdk.xml.dom,jdk.naming.dns,jdk.unsupported,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.jcmd,jdk.internal.ed,jdk.internal.jvmstat,jdk.internal.le,jdk.internal.opt,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.sctp \
+      --add-modules java.base,java.instrument,java.logging,java.management,java.se,java.naming,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,java.xml.crypto,jdk.security.auth,jdk.xml.dom,jdk.naming.dns,jdk.unsupported,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.jcmd,jdk.internal.ed,jdk.internal.jvmstat,jdk.internal.le,jdk.internal.opt,jdk.internal.vm.ci,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.sctp,jdk.compiler \
       --output $JAVA_TARGET && \
       echo "Add Java Debugging tools from JDK" && \
       cp $JAVA_HOME/lib/libjdwp.so $JAVA_TARGET/lib/ && \
@@ -69,12 +69,15 @@ RUN   addgroup -S jboss -g 1000 && \
 COPY --from=keycloak --chown=jboss:jboss /opt/jboss /opt/jboss
 
 COPY --chown=jboss:jboss ./custom-docker-entrypoint.sh $JBOSS_TOOLS/
+COPY --chown=jboss:jboss ./mitigate-cves.java $JBOSS_TOOLS/
 
 # Make tools executable by jboss user
 RUN   chmod 755 $JBOSS_TOOLS/custom-docker-entrypoint.sh
 
 # Switch to jboss user
 USER jboss
+
+RUN  $JAVA_HOME/bin/java $JBOSS_TOOLS/mitigate-cves.java
 
 CMD ["-b", "0.0.0.0"]
 

--- a/keycloak/docker/src/main/docker/keycloak/Dockerfile.plain
+++ b/keycloak/docker/src/main/docker/keycloak/Dockerfile.plain
@@ -12,6 +12,8 @@ RUN true \
 
 USER jboss
 
+RUN  $JAVA_HOME/bin/java $JBOSS_TOOLS/mitigate-cves.java
+
 # Add custom Startup-Scripts
 COPY --chown=jboss:root maven/cli/ /opt/jboss/startup-scripts
 

--- a/keycloak/docker/src/main/docker/keycloak/Dockerfile.plain
+++ b/keycloak/docker/src/main/docker/keycloak/Dockerfile.plain
@@ -10,6 +10,8 @@ RUN true \
     && microdnf clean all \
     && true
 
+COPY --chown=jboss:jboss ./mitigate-cves.java $JBOSS_TOOLS/
+
 USER jboss
 
 RUN  $JAVA_HOME/bin/java $JBOSS_TOOLS/mitigate-cves.java

--- a/keycloak/docker/src/main/docker/keycloak/mitigate-cves.java
+++ b/keycloak/docker/src/main/docker/keycloak/mitigate-cves.java
@@ -4,58 +4,218 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 public class MitigateCves {
+
     public static void main(String[] args) {
 
         System.out.println("### Begin CVE mitigation...");
 
-        String modulesFolder = Optional.ofNullable(System.getenv("MODULES_FOLDER")).orElse("/opt/jboss/keycloak/modules");
-        String baseFolder = modulesFolder + "/system/layers/base";
+        String keycloakHomeFolder = Optional.ofNullable(System.getenv("KEYCLOAK_HOME")).orElse("/opt/jboss/keycloak");
+        String baseModulesFolder = keycloakHomeFolder + "/modules/system/layers/base";
 
         List<CveFix> cveFixes = Arrays.asList(
-                new CveFixReplaceLibrary(baseFolder + "/io/undertow/core/main"
-                        , "undertow-core-2.2.5.Final.jar"
+
+                new CveFixDeleteLibrary(baseModulesFolder + "/org/hornetq"),
+
+                new CveFixDeleteLibrary(baseModulesFolder + "/org/apache/activemq"),
+                new CveFixDeleteLibrary(baseModulesFolder + "/org/wildfly/extension/messaging-activemq"),
+                new CveFixReplaceInFile(baseModulesFolder + "/org/jboss/jts/main/module.xml"
+                        , "<module name=\"org.apache.activemq.artemis.journal\"/>"
+                        , ""
+                ),
+
+                new CveFixDeleteLibrary(keycloakHomeFolder + "/bin/client/jboss-client.jar"),
+
+                new CveFixReplaceLibrary(baseModulesFolder + "/org/apache/sshd/main"
+                        , "sshd-common-${vulnerableVersion}.jar"
                         , "module.xml"
-                        , "undertow-core-2.2.8.Final.jar"
-                        , "https://search.maven.org/remotecontent?filepath=io/undertow/undertow-core/2.2.8.Final/undertow-core-2.2.8.Final.jar"
+                        , "sshd-common-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/apache/sshd/sshd-common/${fixedVersion}/sshd-common-${fixedVersion}.jar"
+                        , "2.4.0"
+                        , "2.7.0"
+
+                ),
+                new CveFixReplaceLibrary(baseModulesFolder + "/org/apache/sshd/main"
+                        , "sshd-core-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "sshd-core-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/apache/sshd/sshd-core/${fixedVersion}/sshd-core-${fixedVersion}.jar"
+                        , "2.4.0"
+                        , "2.7.0"
                 )
-                , new CveFixReplaceLibrary(baseFolder + "/org/apache/commons/io/main"
-                        , "commons-io-2.5.jar"
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/apache/commons/io/main"
+                        , "commons-io-${vulnerableVersion}.jar"
                         , "module.xml"
-                        , "commons-io-2.7.jar"
-                        , "https://search.maven.org/remotecontent?filepath=commons-io/commons-io/2.7/commons-io-2.7.jar"
+                        , "commons-io-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=commons-io/commons-io/${fixedVersion}/commons-io-${fixedVersion}.jar"
+                        , "2.5"
+                        , "2.7"
                 )
-                , new CveFixReplaceLibrary(baseFolder + "/org/apache/activemq/artemis/main"
-                        , "artemis-server-2.16.0.jar"
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/codehaus/jackson/jackson-core-asl/main"
+                        , "jackson-core-asl-${vulnerableVersion}.jar"
                         , "module.xml"
-                        , "artemis-server-2.17.0.jar"
-                        , "https://search.maven.org/remotecontent?filepath=org/apache/activemq/artemis-server/2.17.0/artemis-server-2.17.0.jar"
+                        , "jackson-core-asl-${fixedVersion}.jar"
+                        , "https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-core-asl/${fixedVersion}/jackson-core-asl-${fixedVersion}.jar"
+                        , "1.9.13.redhat-00007"
+                        , "1.9.14.jdk17-redhat-00001"
                 )
-                , new CveFixReplaceLibrary(baseFolder + "/org/apache/thrift/main"
-                        , "libthrift-0.13.0.jar"
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/codehaus/jackson/jackson-jaxrs/main"
+                        , "jackson-jaxrs-${vulnerableVersion}.jar"
                         , "module.xml"
-                        , "libthrift-0.14.2.jar"
-                        , "https://search.maven.org/remotecontent?filepath=org/apache/thrift/libthrift/0.14.2/libthrift-0.14.2.jar"
+                        , "jackson-jaxrs-${fixedVersion}.jar"
+                        , "https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-jaxrs/${fixedVersion}/jackson-jaxrs-${fixedVersion}.jar"
+                        , "1.9.13.redhat-00007"
+                        , "1.9.14.jdk17-redhat-00001"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/codehaus/jackson/jackson-mapper-asl/main"
+                        , "jackson-mapper-asl-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "jackson-mapper-asl-${fixedVersion}.jar"
+                        , "https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-mapper-asl/${fixedVersion}/jackson-mapper-asl-${fixedVersion}.jar"
+                        , "1.9.13.redhat-00007"
+                        , "1.9.14.jdk17-redhat-00001"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/codehaus/jackson/jackson-xc/main"
+                        , "jackson-xc-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "jackson-xc-${fixedVersion}.jar"
+                        , "https://maven.repository.redhat.com/ga/org/codehaus/jackson/jackson-xc/${fixedVersion}/jackson-xc-${fixedVersion}.jar"
+                        , "1.9.13.redhat-00007"
+                        , "1.9.14.jdk17-redhat-00001"
+                )
+
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/picketlink/common/main"
+                        , "picketlink-common-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "picketlink-common-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/picketlink/picketlink-common/${fixedVersion}/picketlink-common-${fixedVersion}.jar"
+                        , "2.5.5.SP12-redhat-00009"
+                        , "2.7.1.Final"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/picketlink/federation/main"
+                        , "picketlink-federation-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "picketlink-federation-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/picketlink/picketlink-federation/${fixedVersion}/picketlink-federation-${fixedVersion}.jar"
+                        , "2.5.5.SP12-redhat-00009"
+                        , "2.7.1.Final"
+                )
+
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/io/undertow/core/main"
+                        , "undertow-core-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "undertow-core-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=io/undertow/undertow-core/${fixedVersion}/undertow-core-${fixedVersion}.jar"
+                        , "2.2.5.Final"
+                        , "2.2.10.Final"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/io/undertow/websocket/main"
+                        , "undertow-websockets-jsr-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "undertow-websockets-jsr-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=io/undertow/undertow-websockets-jsr/${fixedVersion}/undertow-websockets-jsr-${fixedVersion}.jar"
+                        , "2.2.5.Final"
+                        , "2.2.10.Final"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/io/undertow/servlet/main"
+                        , "undertow-servlet-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "undertow-servlet-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=io/undertow/undertow-servlet/${fixedVersion}/undertow-servlet-${fixedVersion}.jar"
+                        , "2.2.5.Final"
+                        , "2.2.10.Final"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/jsoup/main"
+                        , "jsoup-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "jsoup-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/jsoup/jsoup/${fixedVersion}/jsoup-${fixedVersion}.jar"
+                        , "1.8.3"
+                        , "1.14.2"
+                )
+
+                , new CveFixReplaceLibrary(baseModulesFolder + "/org/apache/thrift/main"
+                        , "libthrift-${vulnerableVersion}.jar"
+                        , "module.xml"
+                        , "libthrift-${fixedVersion}.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/apache/thrift/libthrift/${fixedVersion}/libthrift-${fixedVersion}.jar"
+                        , "0.13.0"
+                        , "0.14.2"
                 )
         );
 
         for (var cveFix : cveFixes) {
-            boolean mitigated = cveFix.apply();
-            if (mitigated) {
-                System.out.println("Successfully applied: " + cveFix);
-            } else {
-                System.out.println("Failed to apply: " + cveFix);
+            System.out.println("### Applying: " + cveFix);
+            Result result = cveFix.apply();
+            switch (result) {
+                case FIXED:
+                    System.out.println("## Successfully applied: " + cveFix);
+                    break;
+                case FAILED:
+                    System.out.println("## Failed to apply: " + cveFix);
+                    break;
+                case IGNORED:
+                    System.out.println("## Ignored: " + cveFix);
+                    break;
             }
         }
 
         System.out.println("### Mitigation completed.");
     }
 
-    static interface CveFix {
-        boolean apply();
+    interface CveFix {
+        Result apply();
+    }
+
+    enum Result {
+        FIXED,
+        IGNORED,
+        FAILED
+    }
+
+    static class CveFixReplaceInFile implements CveFix {
+
+        private final String fileToPatch;
+
+        private final String searchRegex;
+
+        private final String replacement;
+
+        public CveFixReplaceInFile(String fileToPatch, String searchRegex, String replacement) {
+            this.fileToPatch = fileToPatch;
+            this.searchRegex = searchRegex;
+            this.replacement = replacement;
+        }
+
+        @Override
+        public Result apply() {
+
+            if (fileToPatch == null) {
+                return Result.IGNORED;
+            }
+
+            if (Utils.replacePatternInFile(fileToPatch, searchRegex, replacement)) {
+                System.out.println("Patched file: " + fileToPatch);
+                return Result.FIXED;
+            }
+
+            return Result.FAILED;
+        }
     }
 
     static class CveFixDeleteLibrary implements CveFix {
@@ -66,8 +226,28 @@ public class MitigateCves {
             this.fileToDelete = fileToDelete;
         }
 
-        public boolean apply() {
-            return fileToDelete != null && deleteFile(fileToDelete);
+        public Result apply() {
+
+            if (fileToDelete == null) {
+                return Result.IGNORED;
+            }
+
+            File file = new File(fileToDelete);
+
+            if (!file.exists()) {
+                System.out.printf("File does not exist: %s%n", file);
+                return Result.IGNORED;
+            }
+
+            if (file.isDirectory()) {
+                return Utils.deleteFolder(file)
+                        ? Result.FIXED
+                        : Result.FAILED;
+            }
+
+            return Utils.deleteFile(file)
+                    ? Result.FIXED
+                    : Result.FAILED;
         }
 
         public String toString() {
@@ -83,75 +263,144 @@ public class MitigateCves {
         final String newUrl;
         final String fixedFileName;
         final String fileToDelete;
+        final String vulnerableVersion;
+        final String fixedVersion;
 
-        public CveFixReplaceLibrary(String moduleFolder, String vulnerableFileName, String fileToPatch, String fixedFileName, String newUrl) {
-            this(moduleFolder, vulnerableFileName, moduleFolder + "/" + fileToPatch, newUrl, fixedFileName, moduleFolder + "/" + vulnerableFileName);
+        public CveFixReplaceLibrary(String moduleFolder, String vulnerableFileName, String fileToPatch, String fixedFileName, String newUrl,
+                                    String vulnerableVersion, String fixedVersion) {
+            this(moduleFolder, vulnerableFileName, moduleFolder + "/" + fileToPatch, newUrl, fixedFileName, moduleFolder + "/" + vulnerableFileName,
+                    vulnerableVersion, fixedVersion);
         }
 
-        public CveFixReplaceLibrary(String moduleFolder, String vulnerableFileName, String fileToPatch, String newUrl, String fixedFileName, String fileToDelete) {
+        public CveFixReplaceLibrary(
+                String moduleFolder, String vulnerableFileName, String fileToPatch, String newUrl, String fixedFileName, String fileToDelete,
+                String vulnerableVersion, String fixedVersion) {
             this.moduleFolder = moduleFolder;
-            this.vulnerableFileName = vulnerableFileName;
+            this.vulnerableVersion = vulnerableVersion;
+            this.fixedVersion = fixedVersion;
             this.fileToPatch = fileToPatch;
-            this.newUrl = newUrl;
-            this.fixedFileName = fixedFileName;
-            this.fileToDelete = fileToDelete;
+            this.newUrl = replaceVersions(newUrl);
+            this.vulnerableFileName = replaceVersions(vulnerableFileName);
+            this.fixedFileName = replaceVersions(fixedFileName);
+            this.fileToDelete = replaceVersions(fileToDelete);
         }
 
-        public boolean apply() {
+        private String replaceVersions(String input) {
 
-            if (newUrl != null && downloadFile(newUrl, moduleFolder + "/" + fixedFileName)) {
-                System.out.println("Downloaded fixed file: " + fixedFileName);
+            if (input == null) {
+                return null;
             }
 
-            if (fileToPatch != null && replaceInFile(fileToPatch, vulnerableFileName, fixedFileName)) {
+            String result = input;
+            if (input.contains("${vulnerableVersion}") && vulnerableVersion != null) {
+                result = result.replace("${vulnerableVersion}", vulnerableVersion);
+            }
+
+            if (input.contains("${fixedVersion}") && fixedVersion != null) {
+                result = result.replace("${fixedVersion}", fixedVersion);
+            }
+
+            return result;
+        }
+
+        public Result apply() {
+
+            if (fileToDelete != null && !new File(fileToDelete).exists()) {
+                System.out.println("Skipping patch, because vulnerable file does not exist: " + fileToDelete);
+                return Result.IGNORED;
+            }
+
+            if (newUrl != null) {
+                boolean downloaded = Utils.downloadFile(newUrl, moduleFolder + "/" + fixedFileName);
+                if (downloaded) {
+                    System.out.println("Downloaded fixed file: " + fixedFileName);
+                } else {
+                    System.out.println("Failed to download fixed file: " + fixedFileName);
+                }
+            }
+
+            if (fileToPatch != null && Utils.replaceInFile(fileToPatch, vulnerableFileName, fixedFileName)) {
                 System.out.println("Patched file: " + fileToPatch);
             }
 
-            if (fileToDelete != null && deleteFile(fileToDelete)) {
+            if (fileToDelete != null && Utils.deleteFile(new File(fileToDelete))) {
                 System.out.println("Vulnerable file deleted: " + fileToDelete);
             }
 
-            return true;
+            return Result.FIXED;
         }
 
         public String toString() {
-            return "CveFixReplaceLibrary: " + fileToDelete + " vulerable file:" + vulnerableFileName + " fixed file:" + fixedFileName;
+            return "CveFixReplaceLibrary: " + fileToDelete + "\nVulnerable file: " + vulnerableFileName + "\nFixed file: " + fixedFileName;
         }
     }
 
-    private static boolean deleteFile(String location) {
-        System.out.printf("Delete file=%s%n", location);
-        boolean deleted = new File(location).delete();
-        if (deleted) {
-            System.out.printf("Successfully deleted file=%s%n", location);
+    static class Utils {
+
+        private static boolean deleteFile(File file) {
+            System.out.printf("Delete file=%s%n", file);
+            boolean deleted = file.delete();
+            if (deleted) {
+                System.out.printf("Successfully deleted file=%s%n", file);
+            }
+            return deleted;
         }
-        return deleted;
-    }
 
-    static boolean replaceInFile(String location, String search, String replace) {
+        static boolean deleteFolder(File file) {
 
-        try {
-            System.out.printf("Replace text in file=%s search=%s replace=%s%n", location, search, replace);
-            Path path = new File(location).toPath();
-            String content = Files.readString(path, StandardCharsets.UTF_8);
-            String replaced = content.replace(search, replace);
-            Files.writeString(path, replaced, StandardCharsets.UTF_8);
-            return true;
-        } catch (Exception ex) {
-            System.err.println("Could not replace file: " + location);
+            try {
+                Files.walk(file.toPath())
+                        .sorted(Comparator.reverseOrder())
+                        .map(Path::toFile)
+                        .forEach(Utils::deleteFile);
+                return true;
+            } catch (Exception ex) {
+                System.err.printf("Could not delete folder %s%n", file);
+                return false;
+            }
+
+        }
+
+        static boolean replaceInFile(String location, String search, String replace) {
+
+            try {
+                System.out.printf("Replace text in file=%s search=%s replace=%s%n", location, search, replace);
+                Path path = new File(location).toPath();
+                String content = Files.readString(path, StandardCharsets.UTF_8);
+                String replaced = content.replace(search, replace);
+                Files.writeString(path, replaced, StandardCharsets.UTF_8);
+                return true;
+            } catch (Exception ex) {
+                System.err.println("Could not replace file: " + location);
+                return false;
+            }
+        }
+
+        static boolean replacePatternInFile(String location, String searchPattern, String replace) {
+
+            try {
+                System.out.printf("Replace text in file=%s search=%s replace=%s%n", location, searchPattern, replace);
+                Path path = new File(location).toPath();
+                String content = Files.readString(path, StandardCharsets.UTF_8);
+                String replaced = content.replaceAll(searchPattern, replace);
+                Files.writeString(path, replaced, StandardCharsets.UTF_8);
+                return true;
+            } catch (Exception ex) {
+                System.err.println("Could not replace file: " + location);
+                return false;
+            }
+        }
+
+        static boolean downloadFile(String url, String targetFile) {
+            try {
+                System.out.println("Downloading file: " + url);
+                URL fileUrl = new URL(url);
+                Files.copy(fileUrl.openStream(), new File(targetFile).toPath());
+                return true;
+            } catch (Exception ex) {
+                System.err.println("Could not download file from url: " + url);
+            }
             return false;
         }
-    }
-
-    static boolean downloadFile(String url, String targetFile) {
-        try {
-            System.out.println("Downloading file: " + url);
-            URL fileUrl = new URL(url);
-            Files.copy(fileUrl.openStream(), new File(targetFile).toPath());
-            return true;
-        } catch (Exception ex) {
-            System.err.println("Could not download file from url: " + url);
-        }
-        return false;
     }
 }

--- a/keycloak/docker/src/main/docker/keycloak/mitigate-cves.java
+++ b/keycloak/docker/src/main/docker/keycloak/mitigate-cves.java
@@ -1,0 +1,157 @@
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class MitigateCves {
+    public static void main(String[] args) {
+
+        System.out.println("### Begin CVE mitigation...");
+
+        String modulesFolder = Optional.ofNullable(System.getenv("MODULES_FOLDER")).orElse("/opt/jboss/keycloak/modules");
+        String baseFolder = modulesFolder + "/system/layers/base";
+
+        List<CveFix> cveFixes = Arrays.asList(
+                new CveFixReplaceLibrary(baseFolder + "/io/undertow/core/main"
+                        , "undertow-core-2.2.5.Final.jar"
+                        , "module.xml"
+                        , "undertow-core-2.2.8.Final.jar"
+                        , "https://search.maven.org/remotecontent?filepath=io/undertow/undertow-core/2.2.8.Final/undertow-core-2.2.8.Final.jar"
+                )
+                , new CveFixReplaceLibrary(baseFolder + "/org/apache/commons/io/main"
+                        , "commons-io-2.5.jar"
+                        , "module.xml"
+                        , "commons-io-2.7.jar"
+                        , "https://search.maven.org/remotecontent?filepath=commons-io/commons-io/2.7/commons-io-2.7.jar"
+                )
+                , new CveFixReplaceLibrary(baseFolder + "/org/apache/activemq/artemis/main"
+                        , "artemis-server-2.16.0.jar"
+                        , "module.xml"
+                        , "artemis-server-2.17.0.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/apache/activemq/artemis-server/2.17.0/artemis-server-2.17.0.jar"
+                )
+                , new CveFixReplaceLibrary(baseFolder + "/org/apache/thrift/main"
+                        , "libthrift-0.13.0.jar"
+                        , "module.xml"
+                        , "libthrift-0.14.2.jar"
+                        , "https://search.maven.org/remotecontent?filepath=org/apache/thrift/libthrift/0.14.2/libthrift-0.14.2.jar"
+                )
+        );
+
+        for (var cveFix : cveFixes) {
+            boolean mitigated = cveFix.apply();
+            if (mitigated) {
+                System.out.println("Successfully applied: " + cveFix);
+            } else {
+                System.out.println("Failed to apply: " + cveFix);
+            }
+        }
+
+        System.out.println("### Mitigation completed.");
+    }
+
+    static interface CveFix {
+        boolean apply();
+    }
+
+    static class CveFixDeleteLibrary implements CveFix {
+
+        final String fileToDelete;
+
+        public CveFixDeleteLibrary(String fileToDelete) {
+            this.fileToDelete = fileToDelete;
+        }
+
+        public boolean apply() {
+            return fileToDelete != null && deleteFile(fileToDelete);
+        }
+
+        public String toString() {
+            return "CveFixDeleteFile " + fileToDelete;
+        }
+    }
+
+    static class CveFixReplaceLibrary implements CveFix {
+
+        final String moduleFolder;
+        final String vulnerableFileName;
+        final String fileToPatch;
+        final String newUrl;
+        final String fixedFileName;
+        final String fileToDelete;
+
+        public CveFixReplaceLibrary(String moduleFolder, String vulnerableFileName, String fileToPatch, String fixedFileName, String newUrl) {
+            this(moduleFolder, vulnerableFileName, moduleFolder + "/" + fileToPatch, newUrl, fixedFileName, moduleFolder + "/" + vulnerableFileName);
+        }
+
+        public CveFixReplaceLibrary(String moduleFolder, String vulnerableFileName, String fileToPatch, String newUrl, String fixedFileName, String fileToDelete) {
+            this.moduleFolder = moduleFolder;
+            this.vulnerableFileName = vulnerableFileName;
+            this.fileToPatch = fileToPatch;
+            this.newUrl = newUrl;
+            this.fixedFileName = fixedFileName;
+            this.fileToDelete = fileToDelete;
+        }
+
+        public boolean apply() {
+
+            if (newUrl != null && downloadFile(newUrl, moduleFolder + "/" + fixedFileName)) {
+                System.out.println("Downloaded fixed file: " + fixedFileName);
+            }
+
+            if (fileToPatch != null && replaceInFile(fileToPatch, vulnerableFileName, fixedFileName)) {
+                System.out.println("Patched file: " + fileToPatch);
+            }
+
+            if (fileToDelete != null && deleteFile(fileToDelete)) {
+                System.out.println("Vulnerable file deleted: " + fileToDelete);
+            }
+
+            return true;
+        }
+
+        public String toString() {
+            return "CveFixReplaceLibrary: " + fileToDelete + " vulerable file:" + vulnerableFileName + " fixed file:" + fixedFileName;
+        }
+    }
+
+    private static boolean deleteFile(String location) {
+        System.out.printf("Delete file=%s%n", location);
+        boolean deleted = new File(location).delete();
+        if (deleted) {
+            System.out.printf("Successfully deleted file=%s%n", location);
+        }
+        return deleted;
+    }
+
+    static boolean replaceInFile(String location, String search, String replace) {
+
+        try {
+            System.out.printf("Replace text in file=%s search=%s replace=%s%n", location, search, replace);
+            Path path = new File(location).toPath();
+            String content = Files.readString(path, StandardCharsets.UTF_8);
+            String replaced = content.replace(search, replace);
+            Files.writeString(path, replaced, StandardCharsets.UTF_8);
+            return true;
+        } catch (Exception ex) {
+            System.err.println("Could not replace file: " + location);
+            return false;
+        }
+    }
+
+    static boolean downloadFile(String url, String targetFile) {
+        try {
+            System.out.println("Downloading file: " + url);
+            URL fileUrl = new URL(url);
+            Files.copy(fileUrl.openStream(), new File(targetFile).toPath());
+            return true;
+        } catch (Exception ex) {
+            System.err.println("Could not download file from url: " + url);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This adds an additional build step to the custom docker image build that allows us to remove / replace or otherwise mitigate CVEs that are contained in the official Keycloak Image.

The cve-mitigation is performed via the `mitigate-cve.java` script which modifies the Keycloak distribution as necessary.