### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,8 @@ d) **Operator** configuring realm and server for different stages
 
 | Tool | Version
 |------|--------
-| Java | 11
-| mvn  | 3.6
+| Java | 17
+| mvn  | 3.8
 | docker | 20.10
 | docker-compose | 1.29 
 


### PR DESCRIPTION
Update envcheck details to reflect current peroject dependencies

While setting up a new Keycloak SPI project using your sample (thanks btw!), I recognized that it couldn't execute according to your readme instructions. I was using Ubuntu with package defaults (openjdk-11 and maven-3.6) and first got an error from maven `invalid target release` for the specified java version (which is set to 17).

After updating to Java 17, my maven version (3.6) complained with a cryptic error which is obviously related to an incompability to Java 17. Updating to maven 3.8 fixed the issue. 

So please find my PR for the README attached.