### PR TITLE
Unit test boot 3

### DIFF
--- a/apps/backend-api-springboot3/pom.xml
+++ b/apps/backend-api-springboot3/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.c4-soft.springaddons</groupId>
+            <artifactId>spring-addons-oauth2-test</artifactId>
+            <version>6.0.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/backend-api-springboot3/src/main/java/com/acme/backend/springboot/users/config/WebSecurityConfig.java
+++ b/apps/backend-api-springboot3/src/main/java/com/acme/backend/springboot/users/config/WebSecurityConfig.java
@@ -1,8 +1,7 @@
 package com.acme.backend.springboot.users.config;
 
-import com.acme.backend.springboot.users.support.access.AccessController;
-import com.acme.backend.springboot.users.support.keycloak.KeycloakJwtAuthenticationConverter;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,80 +11,82 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+import com.acme.backend.springboot.users.support.access.AccessController;
+import com.acme.backend.springboot.users.support.keycloak.KeycloakJwtAuthenticationConverter;
+
+import lombok.RequiredArgsConstructor;
 
 /**
- * Configuration applied on all web endpoints defined for this
- * application. Any configuration on specific resources is applied
- * in addition to these global rules.
+ * Configuration applied on all web endpoints defined for this application. Any configuration on specific resources is applied in addition to these global
+ * rules.
  */
 @Configuration
 @RequiredArgsConstructor
-class WebSecurityConfig {
+public class WebSecurityConfig {
 
-    private final KeycloakJwtAuthenticationConverter keycloakJwtAuthenticationConverter;
+	private final KeycloakJwtAuthenticationConverter keycloakJwtAuthenticationConverter;
 
-    /**
-     * Configures basic security handler per HTTP session.
-     * <p>
-     * <ul>
-     * <li>Stateless session (no session kept server-side)</li>
-     * <li>CORS set up</li>
-     * <li>Require the role "ACCESS" for all api paths</li>
-     * <li>JWT converted into Spring token</li>
-     * </ul>
-     *
-     * @param http security configuration
-     * @throws Exception any error
-     */
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	/**
+	 * Configures basic security handler per HTTP session.
+	 * <p>
+	 * <ul>
+	 * <li>Stateless session (no session kept server-side)</li>
+	 * <li>CORS set up</li>
+	 * <li>Require the role "ACCESS" for all api paths</li>
+	 * <li>JWT converted into Spring token</li>
+	 * </ul>
+	 *
+	 * @param  http      security configuration
+	 * @throws Exception any error
+	 */
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        http.sessionManagement(smc -> {
-            smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        });
-        http.cors(this::configureCors);
-        http.authorizeHttpRequests(ahrc -> {
-            // declarative route configuration
-            // .mvcMatchers("/api").hasAuthority("ROLE_ACCESS")
-            ahrc.requestMatchers("/api/**").access(AccessController::checkAccess);
-            // add additional routes
-            ahrc.anyRequest().fullyAuthenticated(); //
-        });
-        http.oauth2ResourceServer(arsc -> {
-            arsc.jwt().jwtAuthenticationConverter(keycloakJwtAuthenticationConverter);
-        });
+		http.sessionManagement(smc -> {
+			smc.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+		});
+		http.cors(this::configureCors);
+		http.authorizeHttpRequests(ahrc -> {
+			// declarative route configuration
+			// .mvcMatchers("/api").hasAuthority("ROLE_ACCESS")
+			ahrc.requestMatchers("/api/**").access(AccessController::checkAccess);
+			// add additional routes
+			ahrc.anyRequest().fullyAuthenticated(); //
+		});
+		http.oauth2ResourceServer(arsc -> {
+			arsc.jwt().jwtAuthenticationConverter(keycloakJwtAuthenticationConverter);
+		});
 
-        return http.build();
-    }
+		return http.build();
+	}
 
-    @Bean
-    AccessController accessController() {
-        return new AccessController();
-    }
+	@Bean
+	AccessController accessController() {
+		return new AccessController();
+	}
 
-    /**
-     * Configures CORS to allow requests from localhost:30000
-     *
-     * @param cors mutable cors configuration
-     */
-    protected void configureCors(CorsConfigurer<HttpSecurity> cors) {
+	/**
+	 * Configures CORS to allow requests from localhost:30000
+	 *
+	 * @param cors mutable cors configuration
+	 */
+	protected void configureCors(CorsConfigurer<HttpSecurity> cors) {
 
-        UrlBasedCorsConfigurationSource defaultUrlBasedCorsConfigSource = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration corsConfiguration = new CorsConfiguration().applyPermitDefaultValues();
-        corsConfiguration.addAllowedOrigin("https://apps.acme.test:4443");
-        List.of("GET", "POST", "PUT", "DELETE").forEach(corsConfiguration::addAllowedMethod);
-        defaultUrlBasedCorsConfigSource.registerCorsConfiguration("/api/**", corsConfiguration);
+		UrlBasedCorsConfigurationSource defaultUrlBasedCorsConfigSource = new UrlBasedCorsConfigurationSource();
+		CorsConfiguration corsConfiguration = new CorsConfiguration().applyPermitDefaultValues();
+		corsConfiguration.addAllowedOrigin("https://apps.acme.test:4443");
+		List.of("GET", "POST", "PUT", "DELETE").forEach(corsConfiguration::addAllowedMethod);
+		defaultUrlBasedCorsConfigSource.registerCorsConfiguration("/api/**", corsConfiguration);
 
-        cors.configurationSource(req -> {
+		cors.configurationSource(req -> {
 
-            CorsConfiguration config = new CorsConfiguration();
+			CorsConfiguration config = new CorsConfiguration();
 
-            config = config.combine(defaultUrlBasedCorsConfigSource.getCorsConfiguration(req));
+			config = config.combine(defaultUrlBasedCorsConfigSource.getCorsConfiguration(req));
 
-            // check if request Header "origin" is in white-list -> dynamically generate cors config
+			// check if request Header "origin" is in white-list -> dynamically generate cors config
 
-            return config;
-        });
-    }
+			return config;
+		});
+	}
 }

--- a/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/BackendApiSpringboot3AppTests.java
+++ b/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/BackendApiSpringboot3AppTests.java
@@ -1,13 +1,50 @@
 package com.acme.backend.springboot.users;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class BackendApiSpringboot3AppTests {
 
+	@Autowired
+	MockMvc api;
+
 	@Test
-	void contextLoads() {
+	@WithAnonymousUser
+	void givenRequestIsAnonymous_whengetUsersMe_thenUnauthorized() throws Exception {
+		api.perform(get("/api/users/me")).andExpectAll(status().isUnauthorized());
+	}
+
+	@Test
+	@WithMockJwtAuth(claims = @OpenIdClaims(sub = "Tonton Pirate"))
+	void givenUserIsNotGrantedWithAccess_whengetUsersMe_thenForbidden() throws Exception {
+		// @formatter:off
+        api.perform(get("/api/users/me"))
+            .andExpect(status().isForbidden());
+        // @formatter:on
+	}
+
+	@Test
+	@WithMockJwtAuth(authorities = { "ROLE_ACCESS" }, claims = @OpenIdClaims(sub = "Tonton Pirate"))
+	void givenUserIsGrantedWithAccess_whengetUsersMe_thenOk() throws Exception {
+		// @formatter:off
+        api.perform(get("/api/users/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message", is("Hello Tonton Pirate")));
+        // @formatter:on
 	}
 
 }

--- a/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/web/UsersControllerTest.java
+++ b/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/web/UsersControllerTest.java
@@ -1,0 +1,46 @@
+package com.acme.backend.springboot.users.web;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
+
+@WebMvcTest(controllers = UsersController.class)
+class UsersControllerTest {
+	@Autowired
+	MockMvc api;
+
+	@Test
+	void givenRequestIsAnonymous_whengetUsersMe_thenUnauthorized() throws Exception {
+		api.perform(get("/api/users/me")).andExpectAll(status().isUnauthorized());
+	}
+
+	@Test
+	@WithMockJwtAuth(claims = @OpenIdClaims(sub = "Tonton Pirate"))
+	void givenUserIsNotGrantedWithAccess_whengetUsersMe_thenForbidden() throws Exception {
+		// @formatter:off
+        api.perform(get("/api/users/me"))
+            // should be forbidden as user does is not granted with "ROLE_ACCESS"
+            .andExpect(status().isOk());
+        // @formatter:on
+	}
+
+	@Test
+	@WithMockJwtAuth(authorities = { "ROLE_ACCESS" }, claims = @OpenIdClaims(sub = "Tonton Pirate"))
+	void givenUserIsGrantedWithAccess_whengetUsersMe_thenOk() throws Exception {
+		// @formatter:off
+        api.perform(get("/api/users/me"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.message", is("Hello Tonton Pirate")));
+        // @formatter:on
+	}
+
+}

--- a/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/web/UsersControllerTest.java
+++ b/apps/backend-api-springboot3/src/test/java/com/acme/backend/springboot/users/web/UsersControllerTest.java
@@ -8,17 +8,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.acme.backend.springboot.users.config.WebSecurityConfig;
+import com.acme.backend.springboot.users.support.keycloak.KeycloakJwtAuthenticationConverter;
 import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
 import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
 
 @WebMvcTest(controllers = UsersController.class)
+@Import({ WebSecurityConfig.class, KeycloakJwtAuthenticationConverter.class })
 class UsersControllerTest {
+
 	@Autowired
 	MockMvc api;
 
 	@Test
+	@WithAnonymousUser
 	void givenRequestIsAnonymous_whengetUsersMe_thenUnauthorized() throws Exception {
 		api.perform(get("/api/users/me")).andExpectAll(status().isUnauthorized());
 	}
@@ -28,8 +35,7 @@ class UsersControllerTest {
 	void givenUserIsNotGrantedWithAccess_whengetUsersMe_thenForbidden() throws Exception {
 		// @formatter:off
         api.perform(get("/api/users/me"))
-            // should be forbidden as user does is not granted with "ROLE_ACCESS"
-            .andExpect(status().isOk());
+            .andExpect(status().isForbidden());
         // @formatter:on
 	}
 


### PR DESCRIPTION
Add some unit-tests for access-control rules on the only endpoint of the application: `/api/users/me`.

This tests enlight that the _Require the role "ACCESS" for all api paths_ is not implemented (probably a regression when moving from `hasAuthority()` to `access()`). This perfectly illustrates the value of such tests.

As those access control rules are very simple, this is quickly tested.

As most production security implementations involve at some access-rules based on authorities, it could be worth adding some RBAC to this application.