### PR TITLE
Deployment: Allow non-default docker hosts

### DIFF
--- a/apps/oauth2-proxy/docker-compose.yml
+++ b/apps/oauth2-proxy/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - "--tls-cert-file=/cert.pem"
       - "--tls-key-file=/cert.key"
     extra_hosts:
-      # 172.17.0.1 is host.docker.internal
-      - "id.acme.test:172.17.0.1"
+      # ${DOCKER_HOST_IP:-172.17.0.1} is host.docker.internal
+      - "id.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
   upstream-app:
     image: golang:1.19.3-alpine
     volumes:

--- a/deployments/local/dev/docker-compose-keycloak.yml
+++ b/deployments/local/dev/docker-compose-keycloak.yml
@@ -43,9 +43,9 @@ services:
       - "-Dwildfly.statistics-enabled=true"
 #      - "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
     extra_hosts:
-      # 172.17.0.1 is host.docker.internal
-      - "id.acme.test:172.17.0.1"
-      - "apps.acme.test:172.17.0.1"
+      # ${DOCKER_HOST_IP:-172.17.0.1} is host.docker.internal
+      - "id.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "apps.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
     ports:
       - "8080:8080"
       - "8443:8443"

--- a/deployments/local/dev/docker-compose-keycloakx.yml
+++ b/deployments/local/dev/docker-compose-keycloakx.yml
@@ -74,10 +74,10 @@ services:
 #      - "--verbose"
     #      - "-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
     extra_hosts:
-      # 172.17.0.1 is host.docker.internal
-      - "id.acme.test:172.17.0.1"
-      - "apps.acme.test:172.17.0.1"
-      - "ops.acme.test:172.17.0.1"
+      # ${DOCKER_HOST_IP:-172.17.0.1} is host.docker.internal
+      - "id.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "apps.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "ops.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
     ports:
       - "8080:8080"
       - "8443:8443"

--- a/deployments/local/dev/docker-compose-tracing.yml
+++ b/deployments/local/dev/docker-compose-tracing.yml
@@ -11,20 +11,20 @@ services:
     volumes:
       - ../../../config/stage/dev/otel/otel-collector-config.yaml:/etc/otel-collector-config.yaml:z
     extra_hosts:
-      # 172.17.0.1 is host.docker.internal
-      - "id.acme.test:172.17.0.1"
-      - "apps.acme.test:172.17.0.1"
-      - "ops.acme.test:172.17.0.1"
+      # ${DOCKER_HOST_IP:-172.17.0.1} is host.docker.internal
+      - "id.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "apps.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "ops.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
   acme-jaeger:
     image: jaegertracing/all-in-one:1.39
     ports:
       - "16686:16686"
       - "14250:14250"
     extra_hosts:
-      # 172.17.0.1 is host.docker.internal
-      - "id.acme.test:172.17.0.1"
-      - "apps.acme.test:172.17.0.1"
-      - "ops.acme.test:172.17.0.1"
+      # ${DOCKER_HOST_IP:-172.17.0.1} is host.docker.internal
+      - "id.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "apps.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
+      - "ops.acme.test:${DOCKER_HOST_IP:-172.17.0.1}"
   acme-keycloak:
     volumes:
       - ../../../keycloak/config/quarkus-tracing.properties:/opt/keycloak/conf/quarkus.properties:z

--- a/start.java
+++ b/start.java
@@ -58,6 +58,7 @@ class start {
     static final String EXTENSIONS_OPT_JAR = "jar";
     static final String DETACH_OPT = "--detach";
     static final String TRACING_OPT = "--tracing";
+    static final String DOCKER_HOST_OPT = "--docker-host=";
 
     public static void main(String[] args) throws Exception {
 
@@ -81,6 +82,7 @@ class start {
         var useDetach = argList.contains(DETACH_OPT);
         var verbose = argList.contains(VERBOSE_OPT);
         var useTracing = argList.contains(TRACING_OPT);
+        var dockerHost = argList.stream().filter(s -> s.startsWith(DOCKER_HOST_OPT)).map(s -> s.substring(s.indexOf("=") + 1)).findFirst();
 
         var showHelp = argList.contains(HELP_CMD) || argList.isEmpty();
         if (showHelp) {
@@ -247,6 +249,10 @@ class start {
             }
         }
 
+        if (dockerHost.isPresent()) {
+            envVariables.append(String.format("DOCKER_HOST_IP=\"%s\"", dockerHost.get()));
+        }
+
         if (!envVariables.toString().isBlank()) {
             String generatedEnvFile = "generated.env.tmp";
             Files.writeString(Paths.get(generatedEnvFile), envVariables.toString());
@@ -288,6 +294,8 @@ class start {
         System.out.printf("  %s: %s%n", EXTENSIONS_OPT, "choose dynamic extensions extension based on \"classes\" or static based on \"jar\"");
         System.out.printf("  %s: %s%n", DETACH_OPT, "Detached mode: Run containers in the background and prints the container name.. (Optional)");
         System.out.printf("  %s: %s%n", VERBOSE_OPT, "Shows debug information, such as the generated command");
+        System.out.printf("  %s: %s%n", DOCKER_HOST_OPT, "Allows configuring of a non-default IP for reaching the docker host from inside the containers, " +
+                "which is used for name resolution. This is useful for using WiFi on ICE trains, which use the same network as docker by default. This causes the wifi to not work correctly.");
 
         System.out.printf("%n%s supports the following commands: %n", "start.java");
         System.out.println("");
@@ -302,6 +310,7 @@ class start {
         System.out.printf("  %s %s%n", "java start.java --https --database=postgres", "# Start Keycloak Environment with PostgreSQL database");
         System.out.printf("  %s %s%n", "java start.java --https --openldap --database=postgres", "# Start Keycloak Environment with PostgreSQL database and OpenLDAP");
         System.out.printf("  %s %s%n", "java start.java --extensions=classes", "# Start Keycloak with extensions mounted from classes folder. Use --extensions=jar to mount the jar file into the container");
+        System.out.printf("  %s %s%n", "java start.java --docker-host=172.19.0.1", "# Configure a non-default IP for the docker host.");
     }
 
     private static int runCommandAndWait(ArrayList<String> commandLine) {


### PR DESCRIPTION
The setup uses the IP address of the host to resolve some names. When docker is configured to use a different range of IP addresses, this stops working correctly.

The main use case for this is that the WiFi on DB ICE trains allocates IPs from the 172.17.0.0/16 range, which is the same as the default docker network. When both use the same range, problems occur with both docker and the WiFi.